### PR TITLE
docs: added namespace in Secret resource yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: namecheap-credentials
+  namespace: cert-manager
 type: Opaque
 stringData:
   apiKey: my_api_key_from_namecheap


### PR DESCRIPTION
Hello,

Thank you for the awesome work on this webhook it made me really save a lot of time for handling my wildcard certificates with Cert Manager and Namecheap.

I had a problem when setting it up, the Challenge resource created could not find the "nameacheap-credentials" namespace when I created the secret in the default or other namespaces than "cert-manager" (https://github.com/cert-manager/cert-manager/issues/650#issuecomment-396889595 gave me the hint).

I made this PR to update the Secret resource documentation for specifying that the namespace to create the Secret in is cert-manager.

Best regards,