### PR TITLE
Update to require users to specify zone in config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCH ?= $(shell go env GOARCH)
 
 IMAGE_NAME := cert-manager-webhook-namecheap
 IMAGE_TAG := $(shell git describe --dirty)
-REPO_NAME := kelvie
+REPO_NAME := omnibaer
 PLATFORMS := linux/amd64,linux/arm64
 DOCKER_OPTS :=
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ type: Opaque
 stringData:
   apiKey: my_api_key_from_namecheap
   apiUser: my_username_from_namecheap
+  apiDomain: my_domain_from_namecheap
 ```
 
 Now you can create a certificate in staging for testing:

--- a/deploy/letsencrypt-namecheap-issuer/templates/cluster-issuer-prod.yaml
+++ b/deploy/letsencrypt-namecheap-issuer/templates/cluster-issuer-prod.yaml
@@ -23,3 +23,6 @@ spec:
             apiUserSecretRef:
               name: {{ .Values.secret }}
               key: apiUser
+            apiDomainSecretRef:
+              name: {{ .Values.secret }}
+              key: apiDomain

--- a/deploy/letsencrypt-namecheap-issuer/templates/cluster-issuer-stage.yaml
+++ b/deploy/letsencrypt-namecheap-issuer/templates/cluster-issuer-stage.yaml
@@ -23,3 +23,6 @@ spec:
             apiUserSecretRef:
               name: {{ .Values.secret }}
               key: apiUser
+            apiDomainSecretRef:
+              name: {{ .Values.secret }}
+              key: apiDomain

--- a/main.go
+++ b/main.go
@@ -296,11 +296,18 @@ func (c *namecheapDNSProviderSolver) parseChallenge(ch *v1alpha1.ChallengeReques
 	zone string, domain string, err error,
 ) {
 
-	if zone, err = util.FindZoneByFqdn(
-		ch.ResolvedFQDN, util.RecursiveNameservers,
+	// call GetZone instead to resolve from Namecheap. Alternatively:
+    // if zone, err = c.getSecret(cfg.APIDomainSecretRef, ch.ResourceNamespace)
+	// if err != nil {
+	// 	return "", "", err
+	// }
+	// 
+	if zone, err = GetZone(
+		ch.ResolvedFQDN
 	); err != nil {
 		return "", "", err
 	}
+	//
 	zone = util.UnFqdn(zone)
 
 	if idx := strings.Index(ch.ResolvedFQDN, "."+ch.ResolvedZone); idx != -1 {
@@ -363,6 +370,19 @@ func (c *namecheapClientImpl) SetDomain(domain Domain) error {
 		return err
 	}
 	return nil
+}
+
+// prototyped to call getInfo from namecheap SDK and return the domain 
+// name as the zone. Can use user-configured zone instead though
+func (c *namecheapClientImpl) GetZone(domain string) (*zone, error) {
+	resp, err := c.client.DomainsDNS.GetInfo(domain, domain)
+	if err != nil {
+		return nil, err
+	}
+
+    zone := resp.DomainName
+
+	return *zone, nil
 }
 
 func (c *namecheapClientImpl) GetDomain(domain string) (*Domain, error) {

--- a/main.go
+++ b/main.go
@@ -295,19 +295,12 @@ func (c *namecheapDNSProviderSolver) setNamecheapClient(ch *v1alpha1.ChallengeRe
 func (c *namecheapDNSProviderSolver) parseChallenge(ch *v1alpha1.ChallengeRequest) (
 	zone string, domain string, err error,
 ) {
-
 	// call GetZone instead to resolve from Namecheap. Alternatively:
-    // if zone, err = c.getSecret(cfg.APIDomainSecretRef, ch.ResourceNamespace)
-	// if err != nil {
-	// 	return "", "", err
-	// }
-	// 
-	if zone, err = GetZone(
-		ch.ResolvedFQDN
-	); err != nil {
-		return "", "", err
+    zone, err = c.getSecret(cfg.APIDomainSecretRef, ch.ResourceNamespace)
+	if err != nil {
+	 	return "", "", err
 	}
-	//
+	
 	zone = util.UnFqdn(zone)
 
 	if idx := strings.Index(ch.ResolvedFQDN, "."+ch.ResolvedZone); idx != -1 {
@@ -370,19 +363,6 @@ func (c *namecheapClientImpl) SetDomain(domain Domain) error {
 		return err
 	}
 	return nil
-}
-
-// prototyped to call getInfo from namecheap SDK and return the domain 
-// name as the zone. Can use user-configured zone instead though
-func (c *namecheapClientImpl) GetZone(domain string) (*zone, error) {
-	resp, err := c.client.DomainsDNS.GetInfo(domain, domain)
-	if err != nil {
-		return nil, err
-	}
-
-    zone := resp.DomainName
-
-	return *zone, nil
 }
 
 func (c *namecheapClientImpl) GetDomain(domain string) (*Domain, error) {

--- a/testdata/namecheap/apikey.yaml.sample
+++ b/testdata/namecheap/apikey.yaml.sample
@@ -6,3 +6,4 @@ type: Opaque
 data:
   apiKey: "<<BASE64 ENCODED NAMECHEAP API KEY>>"
   apiUser: "<<BASE64 ENCODED NAMECHEAP API USER>>"
+  apiDomain: "<<BASE64 ENCODED NAMECHEAP USER DOMAIN>>"

--- a/testdata/namecheap/config.json.sample
+++ b/testdata/namecheap/config.json.sample
@@ -7,5 +7,9 @@
     "name": "namecheap-credentials",
     "key": "apiUser"
   },
+  "apiDomainSecretRef": {
+    "name": "namecheap-credentials",
+    "key": "apiDomain"
+  },
   "useSandbox": true
 }


### PR DESCRIPTION
See Issue #10. util.FindZoneByFqdn is unreliable and results in truncated DNS records. This PR adds the domain to the namecheap-credentials secret and integrates the key into the code, replacing the errant function.

Considered pulling the zone from the Namecheap API, but given how everything else works with the provider, this is probably the more elegant solution.