### PR TITLE
Enable custom DNS resolvers in the webhook pod

### DIFF
--- a/deploy/cert-manager-webhook-namecheap/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-namecheap/templates/deployment.yaml
@@ -23,6 +23,13 @@ spec:
       {{- if ne .Values.priorityClassName "" }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- with .Values.dns }}
+      dnsPolicy: {{ .dnsPolicy | quote }}
+      {{- with .dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/cert-manager-webhook-namecheap/values.yaml
+++ b/deploy/cert-manager-webhook-namecheap/values.yaml
@@ -27,13 +27,15 @@ service:
   type: ClusterIP
   port: 443
 
-dns:
-  dnsPolicy: "None"
-  dnsConfig:
-    nameservers:
-      - 9.9.9.9
-      - 1.1.1.1
-      - 9.9.9.10
+# Set custom DNS resolvers for the webhook. This is useful if using coredns's host plugin to resolve
+# hostnames covered by any certificates you need to issue.
+dns: {}
+#  dnsPolicy: "None"
+#  dnsConfig:
+#    nameservers:
+#      - 9.9.9.9
+#      - 1.1.1.1
+#      - 9.9.9.10
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/deploy/cert-manager-webhook-namecheap/values.yaml
+++ b/deploy/cert-manager-webhook-namecheap/values.yaml
@@ -27,6 +27,13 @@ service:
   type: ClusterIP
   port: 443
 
+dns:
+  dnsPolicy: "None"
+  dnsConfig:
+    nameservers:
+      - 9.9.9.9
+      - 1.1.1.1
+      - 9.9.9.10
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
This is necessary in a case where the webhook determines the wrong zone due to split-DNS.

E.g.: Set Coredns to resolve private hostnames on domain that is covered by a cert issued with the assistance of this webhook. Coredns will not properly return the authoritative name servers, and the certificate will never issue. By setting the pod's DNS to an external resolver, this problem is avoided.